### PR TITLE
Fix broken Subreddit search

### DIFF
--- a/app/src/main/java/stoyck/vitrina/network/RedditService.kt
+++ b/app/src/main/java/stoyck/vitrina/network/RedditService.kt
@@ -18,7 +18,7 @@ class RedditService @Inject constructor(
     @Named("reddit_client_id")
     private val clientId: String
 ) {
-    private val usernameAndPassword = "$clientId: "
+    private val usernameAndPassword = "$clientId:"
 
     private val authorization: String =
         "Basic " + Base64.encodeToString(


### PR DESCRIPTION
Close #13 

Currently the subreddit search shows 'Something went wrong' on the
UI. The extra space in auth header has been causing the auth request to
throw 401. Removing the space fixes it.

